### PR TITLE
Update CONTIG header regex to accept contigs without length

### DIFF
--- a/tests/test_header_parser.py
+++ b/tests/test_header_parser.py
@@ -5,9 +5,9 @@ def test_parse_vcf_lines():
     """
     Test how the header parser behaves with simple vcf lines
     """
-    
+
     header_parser = HeaderParser()
-    
+
     header_lines = [
         '##fileformat=VCFv4.2',
         '##FILTER=<ID=LowQual,Description="Low quality">',
@@ -31,22 +31,22 @@ def test_parse_vcf_lines():
             header_parser.parse_meta_data(line)
         elif line.startswith('#'):
             header_parser.parse_header_line(line)
-    
+
     assert header_parser.fileformat == "VCFv4.2"
     assert header_parser.individuals == ['father','mother','proband']
-    
+
     assert header_parser.vep_columns == []
-    
+
     assert "MQ" in header_parser.extra_info
     assert header_parser.extra_info["MQ"]['Description'] == "RMS Mapping Quality"
     assert header_parser.extra_info["CNT"]['Number'] == "A"
     assert header_parser.extra_info["CNT"]['Type'] == "Integer"
     assert "CNT" in header_parser.extra_info
     assert "DP_HIST" in header_parser.extra_info
-    
+
     assert "LowQual" in header_parser.filter_dict
     assert "1" in header_parser.contig_dict
-    
+
     assert header_parser.header == [
         'CHROM','POS','ID','REF','ALT','QUAL','FILTER','INFO','FORMAT',
         'father','mother','proband'
@@ -56,13 +56,13 @@ def test_malformed_lines():
     """
     Test how the header parser behaves with simple vcf lines
     """
-    
+
     header_parser = HeaderParser()
-    
+
     malformed_fileformat = '##fileformat'
     malformed_info_line = '##INFO=<ID=MQ,Number=1,Description="RMS Mapping Quality">'
-    malformed_contig_line = '##contig=<ID=1,assembly=b37>'
-    
+    malformed_contig_line = '##contig=<assembly=b37>'
+
     with pytest.raises(SyntaxError):
         header_parser.parse_meta_data(malformed_fileformat)
 
@@ -77,15 +77,10 @@ def test_vep_columns():
     Test how the vep columns are parsed
     """
     header_parser = HeaderParser()
-    
+
     vep_info_line = '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence'\
     ' type as predicted by VEP. Format: Allele|Gene|Feature|Feature_type|Consequence">'
-    
+
     header_parser.parse_meta_data(vep_info_line)
-    
+
     assert header_parser.vep_columns == ['Allele','Gene','Feature','Feature_type','Consequence']
-    
-    
-
-
-    


### PR DESCRIPTION
Sorry for all the whitespaces. Lines that matter are 64 in the `test_header_parser.py` and 122-124 in `header_parser-py`.

I've installed this locally and puzzle can load my VCFs :-)
